### PR TITLE
update get_train_instances() 

### DIFF
--- a/GMF.py
+++ b/GMF.py
@@ -91,7 +91,7 @@ def get_train_instances(train, num_negatives):
         # negative instances
         for t in xrange(num_negatives):
             j = np.random.randint(num_items)
-            while train.has_key((u, j)):
+            while (u, j) in train:
                 j = np.random.randint(num_items)
             user_input.append(u)
             item_input.append(j)

--- a/MLP.py
+++ b/MLP.py
@@ -99,7 +99,7 @@ def get_train_instances(train, num_negatives):
         # negative instances
         for t in xrange(num_negatives):
             j = np.random.randint(num_items)
-            while train.has_key((u, j)):
+            while (u, j) in train:
                 j = np.random.randint(num_items)
             user_input.append(u)
             item_input.append(j)

--- a/NeuMF.py
+++ b/NeuMF.py
@@ -143,7 +143,7 @@ def get_train_instances(train, num_negatives):
         # negative instances
         for t in xrange(num_negatives):
             j = np.random.randint(num_items)
-            while train.has_key((u, j)):
+            while (u, j) in train:
                 j = np.random.randint(num_items)
             user_input.append(u)
             item_input.append(j)


### PR DESCRIPTION
Caused by the APIs of SciPy have been changed
the has_keys() of sparse.dok_matrix is avilable in the : 
[scipy-0.16.1](https://docs.scipy.org/doc/scipy-0.16.1/reference/generated/scipy.sparse.dok_matrix.html#scipy.sparse.dok_matrix) 
but  is disable in the follow version :
[scipy-1.2.1](https://docs.scipy.org/doc/scipy-1.2.1/reference/generated/scipy.sparse.dok_matrix.html?highlight=dok_matrix)
[scipy-1.3.2](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.dok_matrix.html?highlight=dok_matrix)